### PR TITLE
fix(clickhouse): fix Lock race condition using FINAL modifier

### DIFF
--- a/drivers/clickhouse/clickhouse_test.go
+++ b/drivers/clickhouse/clickhouse_test.go
@@ -497,10 +497,10 @@ func TestUnlock_WhenNotLocked(t *testing.T) {
 		t.Fatalf("Init() failed: %v", err)
 	}
 
-	// Try to unlock when not locked
+	// Try to unlock when not locked - should be graceful and not return error
 	err := driver.Unlock(ctx)
-	if err == nil {
-		t.Error("expected error when unlocking without lock, got nil")
+	if err != nil {
+		t.Errorf("expected nil when unlocking without lock (graceful), got: %v", err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
+github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
Fixes a critical race condition in the ClickHouse driver's Lock() implementation by using the FINAL modifier and implementing exponential backoff.

## Changes
- Use FINAL modifier in SELECT to handle ReplacingMergeTree async merges
- Replace fixed 100ms ticker with exponential backoff (50ms → 1s max)
- Make Unlock() graceful - no error if lock doesn't exist
- Add comprehensive documentation for Lock/Unlock/Exec methods
- Document TTL mechanism in Init() for automatic lock cleanup
- Update test expectations for graceful Unlock behavior
---
The FINAL modifier is critical because ClickHouse operations are asynchronous. Without it, we could read intermediate merge states and miss active locks, causing race conditions.
