### PR TITLE
Fix/checksum normalize trim

### DIFF
--- a/internal/checksum/checksum.go
+++ b/internal/checksum/checksum.go
@@ -4,16 +4,49 @@ package checksum
 import (
 	"crypto/sha256"
 	"fmt"
+	"strings"
 )
 
 // Calculate computes a SHA-256 checksum of the given migration content.
 // It concatenates all provided strings and returns the hex-encoded hash.
+//
+// Whitespace is normalized before hashing to prevent false "modified" status
+// when users reformat SQL without changing the actual logic.
 func Calculate(content ...string) string {
 	h := sha256.New()
 
 	for _, c := range content {
-		h.Write([]byte(c))
+		normalized := normalizeWhitecpace(c)
+		h.Write([]byte(normalized))
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// normalizeWhitespace removes leading/trailing whitespace from each line
+// and collapses multiple blank lines into one.
+// This ensures formatting changes don't affect the checksum.
+func normalizeWhitecpace(s string) string {
+	lines := strings.Split(s, "\n")
+	result := make([]string, 0, len(lines))
+
+	prevEmpty := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip consecutive empty lines
+		if trimmed == "" {
+			if !prevEmpty {
+				result = append(result, "")
+				prevEmpty = true
+			}
+			continue
+		}
+		prevEmpty = false
+		result = append(result, trimmed)
+	}
+
+	// Trim leading/trailing empty lines from result
+	return strings.TrimSpace(strings.Join(result, "\n"))
+
 }

--- a/internal/checksum/checksum_test.go
+++ b/internal/checksum/checksum_test.go
@@ -68,3 +68,41 @@ func TestCalculateDifferent(t *testing.T) {
 		t.Errorf("Calculate() produced same hash for different inputs")
 	}
 }
+
+func TestCalculate_WhitespaceNormalization(t *testing.T) {
+	// same checksum
+	sql1 := "CREATE TABLE users (id INT);"
+	sql2 := "  CREATE TABLE users (id INT);  "
+	sql3 := `
+    CREATE TABLE users (id INT);
+  `
+	sql4 := "\t\tCREATE TABLE users (id INT);\n\n"
+
+	checksum1 := Calculate(sql1)
+	checksum2 := Calculate(sql2)
+	checksum3 := Calculate(sql3)
+	checksum4 := Calculate(sql4)
+
+	if checksum1 != checksum2 {
+		t.Errorf("checksum1 != checksum2: %s != %s", checksum1, checksum2)
+	}
+	if checksum1 != checksum3 {
+		t.Errorf("checksum1 != checksum3: %s != %s", checksum1, checksum3)
+	}
+	if checksum1 != checksum4 {
+		t.Errorf("checksum1 != checksum4: %s != %s", checksum1, checksum4)
+	}
+}
+
+func TestCalculate_DifferentContent(t *testing.T) {
+	// dif checksum
+	sql1 := "CREATE TABLE users (id INT);"
+	sql2 := "CREATE TABLE posts (id INT);"
+
+	checksum1 := Calculate(sql1)
+	checksum2 := Calculate(sql2)
+
+	if checksum1 == checksum2 {
+		t.Errorf("different SQL should have different checksum")
+	}
+}


### PR DESCRIPTION
Prevents false modified status when users reformat SQL without changing the actual migration logic